### PR TITLE
fix: change sending data from body to header

### DIFF
--- a/public/js/api/auth/reissue.js
+++ b/public/js/api/auth/reissue.js
@@ -2,10 +2,9 @@ async function reissue() {
     await $.ajax({
         type: "POST",
         url: config.authServer + "/api/auth/reissue",
-        contentType: "application/json; charset=utf-8",
-        data: JSON.stringify({
-            refreshToken: getCookie("refreshToken")
-        }),
+        headers: {
+            Authorization: "Bearer " + getCookie("refreshToken")
+        },
         success: function (res) {
             setCookie("accessToken", res.accessToken, 2 * 60);
             setCookie("refreshToken", res.refreshToken, 24 * 14 * 60);


### PR DESCRIPTION
**Token 갱신 API 수정**

- body로 보내던 refreshToken을 header의 authorization을 통해 전달
- 그 외 로직은 같음